### PR TITLE
Update linting

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,11 @@
+{
+  "plugins": {
+    "lint": {
+      "list-item-indent": false,
+      "maximum-line-length": 119
+    }
+  },
+  "settings": {
+    "commonmark": true
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,10 @@ branches:
 addons:
   apt:
     sources:
+      - google-chrome
       - ubuntu-toolchain-r-test
     packages:
+      - google-chrome-stable
       - g++-4.8
   firefox: 'latest-esr'
 env:
@@ -60,7 +62,7 @@ deploy:
     branch: master
     condition: "$EMBER_TRY_SCENARIO = 'default'"
     node: 'stable'
-    tags: false
+    tags: true
 after_deploy:
 - .travis/publish-gh-pages.sh
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,8 @@
 
 
 # 2.0.0
-**upgraded** to Ember 2.8. 
-**Added** sass and md linting. 
+**upgraded** to Ember 2.8.
+**Added** sass and md linting.
 **Updated** Demo, README and tests
 
 # 1.0.0
@@ -47,7 +47,8 @@
 
 # 0.2.1
 
-* **Removed** application template from `app` directory which was being used by apps not defining their own application template.
+* **Removed** application template from `app` directory which was being used by apps not defining their own
+application template.
 
 # 0.2.0
 
@@ -72,4 +73,3 @@ Use a `# CHANGELOG` section in your Pull Request description to auto-populate th
 # 0.1.0
 No CHANGELOG section found in Pull Request description.
 Use a `# CHANGELOG` section in your Pull Request description to auto-populate the `CHANGELOG.md`
-

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,8 +2,15 @@ The MIT License (MIT)
 
 Copyright (c) 2016
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Should MIME Checking be enabled and the Type set to 'Text', an error will be thr
 ## Testing with ember-hook
 
 ### frost-url-input
-The file picker component is accessible using ember-hook with the top level hook name or you can access the internal components as well -
+The file picker component is accessible using ember-hook with the top level hook name or you can access the internal
+components as well -
 * Default top level hook - `$hook('url-input')`
 * Test button hook - `$hook('<hook-name>-button')`
 * Input field hook - `$hook('<hook-name>-input')`

--- a/package.json
+++ b/package.json
@@ -7,13 +7,10 @@
     "test": "tests"
   },
   "scripts": {
-    "start": "ember server",
     "build": "ember build",
-    "test": "npm run lint && COVERAGE=true ember test",
-    "lint": "npm run eslint && npm run sass-lint && npm run md-lint",
-    "eslint": "eslint *.js addon app blueprints config tests --fix",
-    "md-lint": "remark *.md",
-    "sass-lint": "sass-lint -q -v"
+    "lint": "lint-all-the-things",
+    "start": "ember server",
+    "test": "npm run lint && COVERAGE=true ember test"
   },
   "repository": "git@github.com:ciena-frost/ember-frost-fields.git",
   "engines": {
@@ -51,14 +48,9 @@
     "ember-prop-types": "^3.10.2",
     "ember-resolver": "^2.1.1",
     "ember-spread": "^1.1.1",
-    "ember-test-utils": "^1.8.0",
+    "ember-test-utils": "^1.10.3",
     "ember-truth-helpers": "^1.3.0",
-    "eslint": "^3.14.0",
-    "eslint-config-frost-standard": "^5.3.2",
-    "loader.js": "^4.1.0",
-    "remark-cli": "^2.1.0",
-    "remark-lint": "^5.4.0",
-    "sass-lint": "^1.10.2"
+    "loader.js": "^4.1.0"
   },
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Updated** Travis to only publish when git tags are added in preparation for non-version bump pull requests.
* **Updated** linting to use linting tools from `ember-test-utils`.
