### PR TITLE
Used info, warn and error icons for core

### DIFF
--- a/addon/templates/components/frost-url-input.hbs
+++ b/addon/templates/components/frost-url-input.hbs
@@ -27,7 +27,6 @@
   {{#if urlFormatError}}
     {{frost-icon
       hook=(concat hook '-icon')
-      pack='frost-fields'
       icon='warning'
     }}
   {{/if}}
@@ -42,21 +41,18 @@
   {{#if error}}
     {{frost-icon
       hook=(concat hook '-icon')
-      pack='frost-fields'
       icon='error'
     }}
   {{/if}}
   {{#if undetermined}}
     {{frost-icon
       hook=(concat hook '-icon')
-      pack='frost-fields'
       icon='warning'
     }}
   {{/if}}
   {{#if success}}
     {{frost-icon
       hook=(concat hook '-icon')
-      pack='frost-fields'
       icon='info'
     }}
   {{/if}}

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-frost-fields",
   "dependencies": {
-    "ember": "^2.11.0",
+    "ember": "~2.11.0",
     "ember-cli-shims": "0.1.1",
     "ember-mocha-adapter": "~0.3.1"
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.5.0",
-    "ember-cli": "^2.11.0",
+    "ember-cli": "~2.11.0",
     "ember-cli-chai": "0.3.2",
     "ember-cli-code-coverage": "0.3.5",
     "ember-cli-dependency-checker": "^1.3.0",
@@ -43,7 +43,7 @@
     "ember-concurrency": "0.7.19",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.1.1",
-    "ember-frost-core": "^1.7.5",
+    "ember-frost-core": "^1.11.0",
     "ember-hook": "^1.4.1",
     "ember-load-initializers": "0.6.3",
     "ember-prop-types": "^3.10.2",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Used** `ember-frost-core` info, warning and error icons instead of the local icons
* **Modified** `ember-cli` dependency to `~` instead of `^` to avoid picking up the latest minor version of ember
