### PR TITLE
Upgrade ember-cli to 2.12.3

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,0 @@
-{
-  "extends": ["frost-standard"]
-}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: 'frost-standard'
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# See http://help.github.com/ignore-files/ for more about ignoring files.
+# See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
 /dist
@@ -14,7 +14,7 @@
 /connect.lock
 /coverage/*
 /libpeerconnection.log
-npm-debug.log
+npm-debug.log*
 testem.log
 /typings
 /visual-acceptance

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,5 @@
 /bower_components
-/config
+/config/ember-try.js
 /dist
 /tests
 /tmp
@@ -8,10 +8,9 @@
 .editorconfig
 .ember-cli
 .eslintignore
-.eslintrc
+.eslintrc.js
 .github
 .gitignore
-.jshintrc
 .pullapprove.yml
 .travis
 .watchmanconfig

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ matrix:
   fast_finish: true
   allow_failures:
   - env: EMBER_TRY_SCENARIO=ember-release
+  - node_js: 'stable'
 
 before_install:
 - npm config set spin false

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,8 @@ cache:
 
 env:
   matrix:
-    - EMBER_TRY_SCENARIO=ember-2-8
-    - EMBER_TRY_SCENARIO=default
-    - EMBER_TRY_SCENARIO=ember-release
+    - EMBER_TRY_SCENARIO=ember-lts-2.8
+    - EMBER_TRY_SCENARIO=ember-default
   global:
     - CXX=g++-4.8
     - secure: CfZyOvx0p2gDwr4+cXNh2Yk+H29QRQu40ab5GnOfg1JIKAZtoZ1XE/JTVG0S0MmN7WqDX39D0hOy+mZ94kmQ29/+fU5UU6WdeUZ5bQm9LAlHxETrHf+SHXLi+i/rXX/5Iq6ya4Qt0c00fx1eO5DS8yexwDhtsIsrD3dKCo0IQuVQ9MspTofSBtUOlUZEtloAcZu7lus5fgoDd+acidQloyiC1P+F3zCsWVdGT1yEWYqQzP7H9G6Qh6WQKe4JPPESniobejVnAJWfCupKclefrHY/hFffm4HDbPHzt8ypGOMhEm22GIVbwjyXqh70m8pux3KL6U/xTXE06fzyHYX8weJ4YKetl2dKgRzcjM2Bt8Ynzntzu4b+qIbwReyFSKJBUx2ueChCRowSn/VkJ3CpM7DwYAfBh6rZqxjT0bVGl6cvUEyM5AAXd5yGJufl6v098pKBJdI5u9g1VlZXgJ21LBgakTizLCGC8hT598pktwWirUbEmXKjQSXCNXW4c38M7z4pCtN9u8sqNZnHt50xzoo+mQ4XUmzMIL3KYwg+MNz5EP7JOYzI1C5NuArA4QUXoqjJyAKOyJsNow8EeUk+0lVS70O1wclN25wPZZvHeYrSe8jSMCQUtA5+KT2NpVTk0MMklI8nW5t7SJKYUgBLZr+yeah/MYCo0d6a+TJ7gNk=
@@ -63,7 +62,7 @@ deploy:
     secure: ujEMpzJKyQzh59A1982m2AbBm98b0cfKVMCsz72WRx+2m1D+UHHv7bh7MwsLzzzsxy5lqXlgalfVY4pE8Y8MBXN3zsleMCttP5RdqcuY83shp7SzcNRh5aOQAAlaihzaWm/nRROAyxIp/167boLOYELxtEebal9HHirWls+G91QK92DXRTXO2rM4GgdgsWVCOYYsCIZXyAL3+55o6pta95M46xnmwOrFtU51G7bI2rZx/robyLrDTXCsVnjYNIGNsAovIU8BGmAARZL6j6WTO51P4TBZanwEMvgasJb52OPLD33lCM1eYtR4CadRA/110yRdM4DT8my6ajdgAsFhgsvhx8h+0Bi3T03lJ76ljVxqGELb8brL4oFsXcSnreFB9BctOLLg2vU98IbDZOMrLGjH+q2YRe0+lpSANQ2xnIPsX0wxKVbPEhWX6BV0vzIhG1tmO2L0J4U/yryEKYRKPH9j8GFoBQmsumlDwFb9162g4esDyY1lxCUYS9yjuD9tgufTb6k5NG7bGB15qdO2/n33DYWQ6GqfmmlrA8Nyauoq1YeF5thQkEwd39PETBPDTzmgxB0UAqKt1KCkerFtVIIipXER0OgZdMhwA8aCI+38mAC5SkowqWTyk/fPi2ksXIVGdk+UVQnq1aavoejrS9lOtMVluiATq9075xPaw/U=
   on:
     all_branches: true
-    condition: "$EMBER_TRY_SCENARIO = 'default'"
+    condition: "$EMBER_TRY_SCENARIO = 'ember-default'"
     node: '6.9.1'
     tags: true
 

--- a/.travis/maybe-bump-version.sh
+++ b/.travis/maybe-bump-version.sh
@@ -6,7 +6,7 @@ then
   exit 0
 fi
 
-if [ "$EMBER_TRY_SCENARIO" != "default" ]
+if [ "$EMBER_TRY_SCENARIO" != "ember-default" ]
 then
   echo "Skipping version bump for EMBER_TRY_SCENARIO ${EMBER_TRY_SCENARIO}"
   exit 0

--- a/.travis/maybe-publish-coverage.sh
+++ b/.travis/maybe-publish-coverage.sh
@@ -14,7 +14,7 @@ then
   exit 0
 fi
 
-if [ "$EMBER_TRY_SCENARIO" != "default" ]
+if [ "$EMBER_TRY_SCENARIO" != "ember-default" ]
 then
   echo "Skipping coverage publish for EMBER_TRY_SCENARIO ${EMBER_TRY_SCENARIO}"
   exit 0

--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,6 @@
 {
   "name": "ember-frost-fields",
   "dependencies": {
-    "ember": "~2.11.0",
-    "ember-cli-shims": "0.1.1",
     "ember-mocha-adapter": "~0.3.1"
   }
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,151 +1,36 @@
+/* eslint-env node */
+
 module.exports = {
   scenarios: [
     {
-      name: 'default',
-      bower: {
-        dependencies: { }
-      }
-    },
-    {
-      name: 'ember-1-12',
+      name: 'ember-lts-2.8',
       bower: {
         dependencies: {
-          'ember': '~1.12.0'
+          'ember': 'components/ember#lts-2-8'
         },
         resolutions: {
-          'ember': '~1.12.0'
+          'ember': 'lts-2-8'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
         }
       }
     },
     {
-      name: 'ember-1-13',
+      name: 'ember-lts-2.12',
       bower: {
         dependencies: {
-          'ember': '~1.13.0'
+          'ember': 'components/ember#lts-2-12'
         },
         resolutions: {
-          'ember': '~1.13.0'
+          'ember': 'lts-2-12'
         }
-      }
-    },
-    {
-      name: 'ember-2-0',
-      bower: {
-        dependencies: {
-          'ember': '~2.0.0'
-        },
-        resolutions: {
-          'ember': '~2.0.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-1',
-      bower: {
-        dependencies: {
-          'ember': '~2.1.0'
-        },
-        resolutions: {
-          'ember': '~2.1.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-2',
-      bower: {
-        dependencies: {
-          'ember': '~2.2.0'
-        },
-        resolutions: {
-          'ember': '~2.2.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-3',
-      bower: {
-        dependencies: {
-          'ember': '~2.3.0'
-        },
-        resolutions: {
-          'ember': '~2.3.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-4',
-      bower: {
-        dependencies: {
-          'ember': '~2.4.0'
-        },
-        resolutions: {
-          'ember': '~2.4.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-5',
-      bower: {
-        dependencies: {
-          'ember': '~2.5.0'
-        },
-        resolutions: {
-          'ember': '~2.5.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-6',
-      bower: {
-        dependencies: {
-          'ember': '~2.6.0'
-        },
-        resolutions: {
-          'ember': '~2.6.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-7',
-      bower: {
-        dependencies: {
-          'ember': '~2.7.0'
-        },
-        resolutions: {
-          'ember': '~2.7.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-8',
-      bower: {
-        dependencies: {
-          'ember': '~2.8.0'
-        },
-        resolutions: {
-          'ember': '~2.8.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-9',
-      bower: {
-        dependencies: {
-          'ember': '~2.9.0'
-        },
-        resolutions: {
-          'ember': '~2.9.0'
-        }
-      }
-    },
-    {
-      name: 'ember-2-10',
-      bower: {
-        dependencies: {
-          'ember': '~2.10.0'
-        },
-        resolutions: {
-          'ember': '~2.10.0'
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
         }
       }
     },
@@ -158,6 +43,11 @@ module.exports = {
         resolutions: {
           'ember': 'release'
         }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
       }
     },
     {
@@ -168,6 +58,11 @@ module.exports = {
         },
         resolutions: {
           'ember': 'beta'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
         }
       }
     },
@@ -180,6 +75,17 @@ module.exports = {
         resolutions: {
           'ember': 'canary'
         }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
+      }
+    },
+    {
+      name: 'ember-default',
+      npm: {
+        devDependencies: {}
       }
     }
   ]

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 'use strict'
 
 module.exports = function (/* environment, appConfig */) {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,5 +1,5 @@
-/* global require, module */
-var EmberAddon = require('ember-cli/lib/broccoli/ember-addon')
+/* eslint-env node */
+const EmberAddon = require('ember-cli/lib/broccoli/ember-addon')
 
 module.exports = function (defaults) {
   var app = new EmberAddon(defaults, {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "lint-all-the-things",
     "start": "ember server",
     "test": "npm run lint && npm run test-addon",
-    "test-addon": "EMBER_TRY_SCENARIO=${EMBER_TRY_SCENARIO:=default} && ember try:one $EMBER_TRY_SCENARIO --- COVERAGE=true ember test"
+    "test-addon": "EMBER_TRY_SCENARIO=${EMBER_TRY_SCENARIO:=ember-default} && ember try:one $EMBER_TRY_SCENARIO --- COVERAGE=true ember test"
   },
   "repository": "git@github.com:ciena-frost/ember-frost-fields.git",
   "engines": {
@@ -26,38 +26,38 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "broccoli-asset-rev": "^2.5.0",
-    "ember-cli": "~2.11.0",
+    "broccoli-asset-rev": "^2.4.5",
+    "ember-cli": "2.12.3",
     "ember-cli-chai": "0.3.2",
     "ember-cli-code-coverage": "0.3.5",
     "ember-cli-dependency-checker": "^1.3.0",
-    "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.6",
-    "ember-cli-inject-live-reload": "^1.6.1",
+    "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-mocha": "0.13.2",
-    "ember-cli-test-loader": "^1.1.1",
+    "ember-cli-shims": "^1.0.2",
     "ember-cli-uglify": "^1.2.0",
     "ember-cli-visual-acceptance": "^2.2.0",
     "ember-code-snippet": "^1.8.0",
     "ember-computed-decorators": "0.3.0",
     "ember-concurrency": "0.7.19",
     "ember-disable-prototype-extensions": "^1.1.0",
-    "ember-export-application-global": "^1.1.1",
+    "ember-export-application-global": "^1.0.5",
     "ember-hook": "^1.4.1",
-    "ember-load-initializers": "0.6.3",
+    "ember-load-initializers": "^0.6.0",
     "ember-prop-types": "^3.10.2",
     "ember-resolver": "^2.1.1",
+    "ember-source": "~2.12.0",
     "ember-spread": "^1.1.1",
     "ember-test-utils": "^1.10.3",
     "ember-truth-helpers": "^1.3.0",
-    "loader.js": "^4.1.0"
+    "loader.js": "^4.2.3"
   },
   "keywords": [
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6",
-    "ember-cli-htmlbars": "^1.0.1",
+    "ember-cli-babel": "^5.1.10",
+    "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-sass": "^5.2.0",
     "ember-frost-core": "^1.14.3"
   },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.10",
+    "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-sass": "^5.2.0",
     "ember-frost-core": "^1.14.3"

--- a/testem.js
+++ b/testem.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 var Reporter = require('ember-test-utils/reporter')
 
 module.exports = {

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,7 +1,7 @@
 /* eslint-env node */
 
-'use strict'
-
 module.exports = {
-  name: 'ember-frost-fields'
+  env: {
+    embertest: true
+  }
 }

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 module.exports = function (environment) {
   var ENV = {
     modulePrefix: 'dummy',
@@ -9,6 +11,10 @@ module.exports = function (environment) {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
         // e.g. 'with-controller': true
+      },
+      EXTEND_PROTOTYPES: {
+        // Prevent Ember Data from overriding Date.parse.
+        Date: false
       }
     },
 
@@ -34,7 +40,6 @@ module.exports = function (environment) {
 
   if (environment === 'test') {
     // Testem prefers this...
-    ENV.rootURL = '/'
     ENV.locationType = 'none'
 
     // keep test console output quieter

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -5,16 +5,13 @@ import Application from '../../app'
 import config from '../../config/environment'
 
 export default function startApp (attrs) {
-  let application
-
   let attributes = merge({}, config.APP)
   attributes = merge(attributes, attrs) // use defaults, but you can override;
 
-  run(() => {
-    application = Application.create(attributes)
+  return run(() => {
+    let application = Application.create(attributes)
     application.setupForTesting()
     application.injectTestHelpers()
+    return application
   })
-
-  return application
 }

--- a/tests/index.html
+++ b/tests/index.html
@@ -21,7 +21,7 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
-    <script src="{{rootURL}}testem.js" integrity=""></script>
+    <script src="/testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/test-support.js"></script>
     <script src="{{rootURL}}assets/dummy.js"></script>


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Upgrade `ember-cli` to `2.12.3`