### PR TITLE
Change semver range of ember-resolver to align with other repos

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ember-hook": "^1.4.2",
     "ember-load-initializers": "^0.6.0",
     "ember-prop-types": "5.0.1",
-    "ember-resolver": "^2.1.1",
+    "ember-resolver": "^2.0.3",
     "ember-sinon": "^0.7.0",
     "ember-source": "~2.12.0",
     "ember-spread": "3.0.0",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Change semver range of `ember-resolver` to align with other repos